### PR TITLE
added the three radio buttons on map editor to button group

### DIFF
--- a/UI/main_window.ui
+++ b/UI/main_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>830</width>
-    <height>1240</height>
+    <width>903</width>
+    <height>1471</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,8 +22,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>830</width>
-     <height>21</height>
+     <width>903</width>
+     <height>31</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -84,6 +84,9 @@
         <layout class="QGridLayout" name="gridLayout_6">
          <item row="0" column="1">
           <widget class="QGroupBox" name="groubox_toolbox">
+           <property name="focusPolicy">
+            <enum>Qt::TabFocus</enum>
+           </property>
            <property name="title">
             <string>ToolBox</string>
            </property>
@@ -278,16 +281,25 @@
                 <property name="text">
                  <string>Empty</string>
                 </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">buttonGroup</string>
+                </attribute>
                </widget>
               </item>
               <item>
                <widget class="QRadioButton" name="toolbox_radio_paper_square">
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
                  <string>Squares</string>
                 </property>
                 <property name="checked">
                  <bool>true</bool>
                 </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">buttonGroup</string>
+                </attribute>
                </widget>
               </item>
               <item>
@@ -295,6 +307,9 @@
                 <property name="text">
                  <string>Hexagonal</string>
                 </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">buttonGroup</string>
+                </attribute>
                </widget>
               </item>
              </layout>
@@ -2152,12 +2167,12 @@
    <slot>setNum(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>447</x>
-     <y>140</y>
+     <x>709</x>
+     <y>203</y>
     </hint>
     <hint type="destinationlabel">
-     <x>792</x>
-     <y>147</y>
+     <x>875</x>
+     <y>209</y>
     </hint>
    </hints>
   </connection>
@@ -2168,12 +2183,12 @@
    <slot>setNum(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>784</x>
-     <y>169</y>
+     <x>861</x>
+     <y>165</y>
     </hint>
     <hint type="destinationlabel">
-     <x>801</x>
-     <y>120</y>
+     <x>883</x>
+     <y>167</y>
     </hint>
    </hints>
   </connection>
@@ -2216,14 +2231,17 @@
    <slot>setMaximum(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>263</x>
-     <y>970</y>
+     <x>235</x>
+     <y>1150</y>
     </hint>
     <hint type="destinationlabel">
-     <x>169</x>
-     <y>973</y>
+     <x>144</x>
+     <y>1147</y>
     </hint>
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
Add the empty, square, hexagonal radio buttons to a button group so now they behave properly.

I changed ./UI/main_window.ui . I'm leaving the updated ./lib/main_window_ui.py file out because my generator renders it a little bit differently than yours
