### PR TITLE
Set encounter table

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -46,6 +46,7 @@ class main_window(Ui_MainWindow):
         self.actionConnect_to.triggered.connect(self.launch_connect_window)
         self.actionNew_Campain.triggered.connect(self.new_campain)
         self.button_rollatable.clicked.connect(self.set_encounter_table)
+        self.button_rollamonster.clicked.connect(self.set_monster_stats)
         self.line_treasure_value.returnPressed.connect(self.set_treasure)
         self.button_generate_npc.clicked.connect(self.set_npc)
         self.button_clear_text.clicked.connect(self.clear_generated_npc)
@@ -53,6 +54,13 @@ class main_window(Ui_MainWindow):
 
         self.list_of_encounters = ["_"]*12
         self.treasure_value = self.line_treasure_value.text()
+        # slider for chance encounters on encounters tab
+        self.slider_value = 10
+        # hook up slider change to setter functions
+        self.slider_chanceofencounter.valueChanged[int].connect(self.changevalue)
+    
+    def changevalue(self, value):
+        self.slider_value = value
 
     def launch_host_game(self):
         '''
@@ -114,26 +122,26 @@ class main_window(Ui_MainWindow):
 
     def set_encounter_table(self):
         environment = str(self.combo_environmentofencounter.currentText())
-        list_of_encounters = get_random_encounters_table(get_monster_dict_xml(),environment)
-        self.label_nameofrolledmonster_1.setText(list_of_encounters[0])
-        self.label_nameofrolledmonster_2.setText(list_of_encounters[1])
-        self.label_nameofrolledmonster_3.setText(list_of_encounters[2])
-        self.label_nameofrolledmonster_4.setText(list_of_encounters[3])
-        self.label_nameofrolledmonster_5.setText(list_of_encounters[4])
-        self.label_nameofrolledmonster_6.setText(list_of_encounters[5])
-        self.label_nameofrolledmonster_7.setText(list_of_encounters[6])
-        self.label_nameofrolledmonster_8.setText(list_of_encounters[7])
-        self.label_nameofrolledmonster_9.setText(list_of_encounters[8])
-        self.label_nameofrolledmonster_10.setText(list_of_encounters[9])
-        self.label_nameofrolledmonster_11.setText(list_of_encounters[10])
-        self.label_nameofrolledmonster_12.setText(list_of_encounters[11])
+        self.list_of_encounters = get_random_encounters_table(get_monster_dict_xml(),environment)
+        self.label_nameofrolledmonster_1.setText(self.list_of_encounters[0])
+        self.label_nameofrolledmonster_2.setText(self.list_of_encounters[1])
+        self.label_nameofrolledmonster_3.setText(self.list_of_encounters[2])
+        self.label_nameofrolledmonster_4.setText(self.list_of_encounters[3])
+        self.label_nameofrolledmonster_5.setText(self.list_of_encounters[4])
+        self.label_nameofrolledmonster_6.setText(self.list_of_encounters[5])
+        self.label_nameofrolledmonster_7.setText(self.list_of_encounters[6])
+        self.label_nameofrolledmonster_8.setText(self.list_of_encounters[7])
+        self.label_nameofrolledmonster_9.setText(self.list_of_encounters[8])
+        self.label_nameofrolledmonster_10.setText(self.list_of_encounters[9])
+        self.label_nameofrolledmonster_11.setText(self.list_of_encounters[10])
+        self.label_nameofrolledmonster_12.setText(self.list_of_encounters[11])
 
     def set_monster_stats(self):
         chance_of_encounter = self.slider_chanceofencounter.value()
-        chosen_monster = get_a_monster(self.list_of_encounters, chance_of_encounter)
+        chosen_monster = get_a_monster(self.list_of_encounters, self.slider_value)
         life, ac, movement, attacks, damages, number_met, save_poison, save_wands,\
         save_paralysis, save_dragon, save_spells, moral, treasure, alignment,\
-        xp_value = get_a_monster_stats(get_monster_dict(), chosen_monster)
+        xp_value = get_a_monster_stats(get_monster_dict_xml(), chosen_monster)
         
         self.group_statsofrolledmonster.setTitle("Stats of Rolled Monster : {0}".format(chosen_monster))
         #self.label_statsofrolledmonster_ac

--- a/launch.py
+++ b/launch.py
@@ -144,7 +144,20 @@ class main_window(Ui_MainWindow):
         xp_value = get_a_monster_stats(get_monster_dict_xml(), chosen_monster)
         
         self.group_statsofrolledmonster.setTitle("Stats of Rolled Monster : {0}".format(chosen_monster))
-        #self.label_statsofrolledmonster_ac
+        self.monster_ac_value.setText(ac)
+        self.monster_movement_value.setText(movement)
+        self.monster_attack_value.setText(attacks)
+        self.monster_damages_value.setText(damages)
+        self.monster_moral_value.setText(moral)
+        self.monster_treasure_value.setText(treasure)
+        self.monster_alignment_value.setText(alignment)
+        self.monster_xp_value.setText(xp_value)
+        self.monster_saves_poison_value.setText(save_poison)
+        self.monster_saves_wands_value.setText(save_wands)
+        self.monster_saves_paralysis_value.setText(save_paralysis)
+        self.monster_saves_dragonbreath_value.setText(save_dragon)
+        self.monster_saves_spells_value.setText(save_spells)
+
 
     def set_treasure(self):
         #Variables used

--- a/launch.py
+++ b/launch.py
@@ -114,7 +114,7 @@ class main_window(Ui_MainWindow):
 
     def set_encounter_table(self):
         environment = str(self.combo_environmentofencounter.currentText())
-        list_of_encounters = get_random_encounters_table(get_monster_dict(),environment)
+        list_of_encounters = get_random_encounters_table(get_monster_dict_xml(),environment)
         self.label_nameofrolledmonster_1.setText(list_of_encounters[0])
         self.label_nameofrolledmonster_2.setText(list_of_encounters[1])
         self.label_nameofrolledmonster_3.setText(list_of_encounters[2])

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -67,7 +67,7 @@ def get_monster_dict_xml():
 
     # load and iterate through the monsters.xml file    
     tree = ET()
-    tree.parse("../resources/cfg/monsters.xml")
+    tree.parse("./resources/cfg/monsters.xml")
     root = tree.getroot()
     monster_list = []
     for monster in root.iter('monster'):
@@ -87,7 +87,7 @@ def get_random_encounters_table(monster_list, environment):
     list_encounters=[""]*12
     monsters_that_can_be_picked=[]
     for index, stats in enumerate(monster_list):
-        if stats["environment"] == environment:
+        if stats["environment_name"] == environment:
             monsters_that_can_be_picked.append(stats["name"])
     for i in range(12):
         try:

--- a/lib/functions.py
+++ b/lib/functions.py
@@ -99,7 +99,7 @@ def get_random_encounters_table(monster_list, environment):
 
 def get_a_monster(list_encounters, chance_encounter):
     dice = rd.randint(1,12)
-    chance = rd.randint(1,100)
+    chance = rd.randint(1,90)
     if chance <= chance_encounter:
         return list_encounters[dice]
     else:
@@ -112,7 +112,12 @@ def get_a_monster_stats(monster_dict, name):
         assert name != "No Monster Met", "no monster met, no stat to retrieve"
     except AssertionError:
         return ("_")*15
-    stats_of_monster = monster_dict[name]
+        
+    stats_of_monster = None
+    for diction in monster_dict:
+        if diction['name'] == name:
+            stats_of_monster = diction
+        
     
     #Getting the life points of monster : life => 3d6-1 => (3 x 6-sided dices) minus 1
     life = dice_roll(stats_of_monster["life"])
@@ -120,7 +125,8 @@ def get_a_monster_stats(monster_dict, name):
     movement = stats_of_monster["movement"] #Getting the movement value
     attacks = stats_of_monster["attacks"]
     damages = stats_of_monster["damages"]
-    number_met = dice_roll(stats_of_monster["number_met"])
+    #number_met = dice_roll(stats_of_monster["number_met"])
+    number_met = 0
     save_poison = stats_of_monster["saves"].split(";")[0]
     save_wands = stats_of_monster["saves"].split(";")[1]
     save_paralysis = stats_of_monster["saves"].split(";")[2]
@@ -129,7 +135,7 @@ def get_a_monster_stats(monster_dict, name):
     moral = stats_of_monster["moral"]
     treasure = stats_of_monster["treasure"]
     alignment = stats_of_monster["alignment"]
-    xp_value = stats_of_monster["xp_value"]
+    xp_value = stats_of_monster["xp"]
     return life, ac, movement, attacks, damages, number_met, save_poison, save_wands,\
     save_paralysis, save_dragon, save_spells, moral, treasure, alignment, xp_value
 

--- a/resources/cfg/monsters.xml
+++ b/resources/cfg/monsters.xml
@@ -16,7 +16,157 @@
         <xp>25</xp>
     </monster>
     <monster>
-        <name>Gobelin2</name>
+        <name>Gobelin Master</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Overlord</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Minor</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Red</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Blue</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Diseased</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Cursed</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Coward</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+        <monster>
+        <name>Gobelin Enchanted</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+            <monster>
+        <name>Undead Gobelin</name>
+        <environment_name>Lair (Gobelin)</environment_name>
+        <life>1d6</life>
+        <ac>7</ac>
+        <movement>30ft</movement>
+        <attacks>sword</attacks>
+        <damages>1d6</damages>
+        <numbers_met>1d4</numbers_met>
+        <saves>10;10;10;10;10</saves>
+        <moral>8</moral>
+        <treasure>50</treasure>
+        <alignment>chaotic evil</alignment>
+        <xp>25</xp>
+    </monster>
+            <monster>
+        <name>Gobelin Shaman</name>
         <environment_name>Lair (Gobelin)</environment_name>
         <life>1d6</life>
         <ac>7</ac>


### PR DESCRIPTION
Did some work on the encounter tab. Roll table and Roll monster both now work. All the monsters in the xml file are under the "Lair (goblin)" environment. 

I padded out the monster.xml file so that we can roll a full table. Each monster has a different name, but the rest of the stats are the same. It was a quick copy/past so I could fill out the monster list.

In functions.py I had to change "get_a_monster_stats" . The monster_dict is actually a list of dictionaries, so I have to parse the list to find the right dictionary then proceed. I skipped number_met key since it wasn't in the dictionary, but I figured out the problem and will commit  that fix in a minute. 

There is a problem with the silder. While debugging I found out that the silder for the chance of encounter doesn't resister past 89.  For the time being I just bumped the upper bound on randint() to 80 on line 102 of functions. It might just be a problem with how I was displaying the value. I did try a different method of find the silder value. It's on line 57-63 in launch.py  but doesn't seem to make a difference.

I had to change "../resources/cfg/monsters.xml" to "./resources/cfg/monsters.xml" in line 70 in functions.py to get it to read the xml file. I think since the program is running in the apps root, the path doesn't need to have the ".." since it's actually not running in the ./lib folder. At least that's how it works on my system.

![screenshot from 2015-08-22 21 37 41](https://cloud.githubusercontent.com/assets/4706284/9426958/33c20a64-4916-11e5-9530-29dc3e2bf3dc.png)
